### PR TITLE
[fix] 修复使用"last"指令无法切换到上一项枪械的问题

### DIFF
--- a/Soldier76.lua
+++ b/Soldier76.lua
@@ -768,7 +768,9 @@ function pubg.findInSeries (cmd)
 			pubg.gunIndex = pubg.gunIndex + 1
 		end
 	elseif "last" == cmd then
-		pubg.gunIndex = #pubg.gun[pubg.bulletType]
+		if pubg.gunIndex > 1 then
+			pubg.gunIndex = pubg.gunIndex - 1
+		end
 	end
 
 	pubg.setGun(pubg.gun[pubg.bulletType][pubg.gunIndex])


### PR DESCRIPTION
修复使用"last"指令无法切换到上一项枪械的问题